### PR TITLE
WIP: Feature #5: Expression editor issues fixes

### DIFF
--- a/src/editor/components/editor-expression-modal.ts
+++ b/src/editor/components/editor-expression-modal.ts
@@ -3,7 +3,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { Ref, createRef, ref } from 'lit/directives/ref.js';
 import { editorExpressionCustomEvent } from '../editor-custom-events';
 import { globalStyles } from '../global-styles';
-import { ExpressionOperator } from '@/index';
+import { Expression, ExpressionOperator } from '@/index';
 
 type ExpressionModalCurrentView = 'expressions' | 'addOperand';
 
@@ -28,7 +28,7 @@ export class EditorExpressionModal extends LitElement {
     `,
   ];
 
-  @property() expression: any;
+  @property() expression: Expression;
   @property() expressionModalCurrentView: ExpressionModalCurrentView = 'expressions';
   @property() selectedAddExpression: any;
   @property() highlightedExpr: HTMLElement;

--- a/src/editor/components/editor-expression-operand-list.ts
+++ b/src/editor/components/editor-expression-operand-list.ts
@@ -365,7 +365,7 @@ export class EditorExpressionOperandList extends LitElement {
   render() {
     return html`
       <div class="expr-opd-list-wrapper">
-        ${this.operands.length < 1
+        ${!this.operands || this.operands.length < 1
           ? html`
               <div class="no-opd-message" style="${this.nestedLevel > 0 ? 'padding-top: 10px;' : ''}">
                 <div>Click on "+ Add Operand"</div>
@@ -492,7 +492,7 @@ export class EditorExpressionOperandList extends LitElement {
                         <editor-button
                           class="expr-control-button"
                           @click="${this.handleEnterGroupMode}"
-                          ?disabled="${this.operands.length < 1}">
+                          ?disabled="${this.operands?.length < 1}">
                           <editor-icon .icon="${check2square}"></editor-icon>
                           <span>Select ...</span>
                         </editor-button>

--- a/src/editor/components/editor-expression-operand-list.ts
+++ b/src/editor/components/editor-expression-operand-list.ts
@@ -407,7 +407,7 @@ export class EditorExpressionOperandList extends LitElement {
                               .visibleOnRender="${this.opdModalVisibleOnRender}">
                             </editor-expression-operand>
                           `}
-                      ${!(operand as Expression).value &&
+                      ${this.operands.length > 1 &&
                       !this.groupModeIsActive &&
                       (this.exprIsSelected || this.nestedLevel === 0) &&
                       !this.isExample

--- a/src/editor/components/editor-expression.ts
+++ b/src/editor/components/editor-expression.ts
@@ -317,7 +317,7 @@ export class EditorExpression extends LitElement {
                 id="opr-type-select"
                 .value="${this.selectedOprType}"
                 @change="${this.handleSelectOprType}">
-                <option value="bool">Logical</option>
+                <option value=${Types.boolean}>Logical</option>
                 <option value="compare">Compare</option>
                 <option value="numeric">Numeric</option>
               </select>

--- a/src/editor/components/ge-statement-argument.ts
+++ b/src/editor/components/ge-statement-argument.ts
@@ -8,7 +8,7 @@ import {
   ProgramStatementArgument,
   UnitLanguageStatementWithArgs,
   initDefaultArgumentType,
-  parseExpressionToString,
+  parseExpressionToString, BoolOperator, isExpressionOperator
 } from '@/index';
 import { consume } from '@lit/context';
 import { LitElement, html, css, nothing } from 'lit';
@@ -253,8 +253,13 @@ export class GeStatementArgument extends LitElement {
 
   render() {
     let argumentElementId = uuidv4();
+    let argumentType = this.argument.type;
 
-    switch (this.argument.type as ArgumentType | 'device') {
+    if (isExpressionOperator(this.argument.type)) {
+      argumentType = Types.boolean_expression;
+    }
+
+    switch (argumentType as ArgumentType | 'device' | BoolOperator) {
       case Types.boolean:
         return html`
           <div class="argument-wrapper">

--- a/src/vpl/program.ts
+++ b/src/vpl/program.ts
@@ -357,7 +357,7 @@ type NumericOperatorsTuple = typeof numericOperators;
 export type NumericOperator = NumericOperatorsTuple[number];
 
 export const isExpressionOperator = (operator: string) => {
-  return operator in compareOperators || operator in boolOperators || operator in numericOperators;
+  return compareOperators.includes(operator as CompareOperator) || boolOperators.includes(operator as BoolOperator) || numericOperators.includes(operator as NumericOperator);
 }
 
 export const isExpressionArray = (argument: ProgramStatementArgument) => Array.isArray(argument.value);


### PR DESCRIPTION
- [x] 1. Operands in an expression no longer have "reorder" (up/down) arrow buttons next to them.
- [ ] 2. Operands are reordered based on selection order when they are grouped.
- [ ] 3. clicking `cancel` in the `Add operand` modal does not actually cancel the operation and the operand is added regardless.
- [x] 4. the implicit top `Expression` block in the expression editor can be modified -- its type can be changed
